### PR TITLE
Interrupt transitions more safely #1821

### DIFF
--- a/src/helpers/d3.axisWithLabelPicker.js
+++ b/src/helpers/d3.axisWithLabelPicker.js
@@ -167,11 +167,13 @@ export default function axisSmart() {
           d3.select(this).select("text")
             .interrupt()
             .style("opacity", getOpacity(d,t))
+            .transition();
         })
           
         g.select('.vzb-axis-value')
           .interrupt()
-          .attr("transform", getTransform);
+          .attr("transform", getTransform)
+          .transition();
           
       }
 

--- a/src/helpers/labels.js
+++ b/src/helpers/labels.js
@@ -241,10 +241,12 @@ var label = function(context) {
       } else {
         labelGroup
             .interrupt()
-            .attr("transform", "translate(" + _X + "," + _Y + ")");
+            .attr("transform", "translate(" + _X + "," + _Y + ")")
+            .transition();
         lineGroup
             .interrupt()
-            .attr("transform", "translate(" + _X + "," + _Y + ")");
+            .attr("transform", "translate(" + _X + "," + _Y + ")")
+            .transition();
         if(showhide) labelGroup.classed("vzb-invisible", d.hidden);
         if(showhide) lineGroup.classed("vzb-invisible", d.hidden);
       }

--- a/src/tools/agepyramid/agepyramid-component.js
+++ b/src/tools/agepyramid/agepyramid-component.js
@@ -672,7 +672,7 @@ var AgePyramid = Component.extend({
       this.year.transition().duration(duration).ease("linear")
         .each("end", this._setYear(time.value));
     } else {
-      this.year.interrupt().text(time.timeFormat(time.value));
+      this.year.interrupt().text(time.timeFormat(time.value)).transition();
     }
       
 

--- a/src/tools/bubblechart/bubblechart-component.js
+++ b/src/tools/bubblechart/bubblechart-component.js
@@ -1225,7 +1225,8 @@ var BubbleChartComp = Component.extend({
         view.interrupt()
           .attr("cy", _this.yScale(valueY))
           .attr("cx", _this.xScale(valueX))
-          .attr("r", scaledS);
+          .attr("r", scaledS)
+          .transition();
 
         //show entity if it was hidden
         if(showhide) view.classed("vzb-invisible", d.hidden);

--- a/src/tools/bubblemap/bubblemap-component.js
+++ b/src/tools/bubblemap/bubblemap-component.js
@@ -215,7 +215,7 @@ var BubbleMapComponent = Component.extend({
       _this._labels.updateSize();
       _this.redrawDataPoints();
       //_this._selectlist.redraw();
-      
+
     });
 
     this.KEY = this.model.entities.getDimension();
@@ -606,7 +606,8 @@ var BubbleMapComponent = Component.extend({
                   .attr("r", d.r);
           }else{
               view.interrupt()
-                  .attr("r", d.r);
+                  .attr("r", d.r)
+                  .transition();
           }
 
           _this._updateLabel(d, index, d.cLoc[0], d.cLoc[1], valueS, valueC, d.label, duration);


### PR DESCRIPTION
During playing we create transitions every interval, but those transitions will run only when next requestAnimationFrame is called. If resize event is came before requestAnimationFrame then selection.interrupt doesn't break those transitions and they are started on coming requestAnimationFrame.