### PR TITLE
Time limits do not return to the broader defaults when switching indicator

### DIFF
--- a/preview/assets/js/toolconfigs/BubbleChart-gapminder.js
+++ b/preview/assets/js/toolconfigs/BubbleChart-gapminder.js
@@ -16,8 +16,8 @@ var VIZABI_MODEL = {
       "dim": "tag"
     },
     "time": {
-      "start": "1800",
-      "end": "2015",
+      "startOrigin": "1800",
+      "endOrigin": "2015",
       "value": "2015"
     },
     "marker": {

--- a/src/base/tool.js
+++ b/src/base/tool.js
@@ -162,11 +162,11 @@ var Tool = Component.extend({
       // change start and end (but keep startOrigin and endOrigin for furhter requests)
       // change is not persistent if it's splashscreen change
       var newTime = {}
-      if(time.start - tLimits.min != 0) newTime['start'] = d3.max([tLimits.min, time.parseToUnit(time.getDefaults().start)]);
-      if(time.end - tLimits.max != 0) newTime['end'] = d3.min([tLimits.max, time.parseToUnit(time.getDefaults().end)]);
+      if(time.start - tLimits.min != 0) newTime['start'] = d3.max([tLimits.min, time.parseToUnit(time.startOrigin)]);
+      if(time.end - tLimits.max != 0) newTime['end'] = d3.min([tLimits.max, time.parseToUnit(time.endOrigin)]);
       if(time.value == null) newTime['value'] = new Date(); // default to current date. Other option: newTime['start'] || newTime['end'] || time.start || time.end;
 
-      time.set(newTime, false, !time.splash);
+      time.set(newTime, false, false);
     }
       
     //force time validation because time.value might now fall outside of start-end

--- a/src/helpers/d3.axisWithLabelPicker.js
+++ b/src/helpers/d3.axisWithLabelPicker.js
@@ -133,7 +133,7 @@ export default function axisSmart() {
     axis.highlightValueRun = function(g) {
 
       //if viewport is defined and HL value is outside then behave as reset HL
-      if(options.viewportLength && (
+      if(options.viewportLength && highlightValue != "none" && (
         axis.scale()(highlightValue) > options.viewportLength ||
         axis.scale()(highlightValue) < 0
       )) highlightValue = "none";

--- a/src/models/time.js
+++ b/src/models/time.js
@@ -32,8 +32,10 @@ var TimeModel = Model.extend({
   _defaults: {
     dim: "time",
     value: null,
-    start: null, //mandatory defaults! 
-    end: null, //mandatory defaults!
+    start: null, 
+    end: null,
+    startOrigin: null,
+    endOrigin: null,
     startSelected: null,
     endSelected: null,
     playable: true,
@@ -154,6 +156,10 @@ var TimeModel = Model.extend({
    * Validates the model
    */
   validate: function() {
+    
+    //check if time start and end are not defined but start and end origins are defined
+    if(this.start == null && this.startOrigin) this.set("start", this.startOrigin, null, false);
+    if(this.end == null && this.endOrigin) this.set("start", this.endOrigin, null, false);
 
     //unit has to be one of the available_time_units
     if(!formats[this.unit]) {
@@ -264,8 +270,8 @@ var TimeModel = Model.extend({
    * @returns {Object} time filter
    */
   getFilter: function(firstScreen) {
-    var defaultStart = this.parseToUnit(this._defaults.start, this.unit);
-    var defaultEnd = this.parseToUnit(this._defaults.end, this.unit);
+    var defaultStart = this.parseToUnit(this.startOrigin, this.unit);
+    var defaultEnd = this.parseToUnit(this.endOrigin, this.unit);
       
     var dim = this.getDimension();
     var filter = null;


### PR DESCRIPTION
this is a suggestion fix for bug #2090

Let time start-end always be defined by the data available. Let user set start-end origins and these origins used to make requests and return start-end to normal after the new data arrives. We were using time _defaults in this situations but nobody sets them really.

