### PR TITLE
Fix scaleType nominal error in axis model

### DIFF
--- a/src/models/axis.js
+++ b/src/models/axis.js
@@ -6,15 +6,15 @@ import Hook from 'models/hook';
  */
 
 var AxisModel = Hook.extend({
-  
+
   //some hooks can be important. like axis x and y
   //that means, if X or Y doesn't have data at some point, we can't show markers
   _important: true,
-  
+
   /**
    * Default values for this model
    */
-  getClassDefaults: function() { 
+  getClassDefaults: function() {
     var defaults = {
       use: null,
       which: null,
@@ -29,15 +29,15 @@ var AxisModel = Hook.extend({
     };
     return utils.deepExtend(this._super(), defaults)
   },
-    
+
   _type: "axis",
 
   /**
    * Validates a color hook
    */
-  validate: function() {    
+  validate: function() {
     this._super();
-    
+
     //restore the correct object type for time values
     if(this.scale && this.scaleType == "time") {
       var obj = {};
@@ -52,37 +52,44 @@ var AxisModel = Hook.extend({
    * Gets the domain for this hook
    * @returns {Array} domain
    */
-  buildScale: function(scaleType = this.scaleType) {
-    var domain;
+  buildScale(scaleType = this.scaleType) {
+    let domain;
 
-    if(scaleType == "time") {
-      
-      var timeMdl = this._space.time;
-      var limits = timeMdl.splash ? 
-          {min: timeMdl.parseToUnit(timeMdl.startOrigin), max: timeMdl.parseToUnit(timeMdl.endOrigin)}
-          :
-          {min: timeMdl.start, max: timeMdl.end};
-      
+    if (scaleType == 'time') {
+      const timeMdl = this._space.time;
+      const limits = timeMdl.splash ?
+        {
+          min: timeMdl.parseToUnit(timeMdl.startOrigin),
+          max: timeMdl.parseToUnit(timeMdl.endOrigin)
+        } :
+        {
+          min: timeMdl.start,
+          max: timeMdl.end
+        };
+
       domain = [limits.min, limits.max];
       this.scale = d3.time.scale.utc().domain(domain);
-
-    }else{
-
-      if(!this.isDiscrete()){
-        var limits = this.getLimits(this.which);
+    } else {
+      if (!this.isDiscrete()) {
+        const limits = this.getLimits(this.which);
         //default domain is based on limits
         domain = [limits.min, limits.max];
         //min and max can override the domain if defined
-        domain[0] = this.domainMin!=null ? +this.domainMin : domain[0];
-        domain[1] = this.domainMax!=null ? +this.domainMax : domain[1];
-      }else{
-        domain = this.use === "constant"? [this.which] : this.getUnique(this.which);
+        domain[0] = this.domainMin != null ? +this.domainMin : domain[0];
+        domain[1] = this.domainMax != null ? +this.domainMax : domain[1];
+      } else {
+        domain = this.use === 'constant' ? [this.which] : this.getUnique(this.which);
       }
 
-      scaleType = (d3.min(domain)<=0 && d3.max(domain)>=0 && scaleType === "log")? "genericLog" : scaleType;
-      this.scale = d3.scale[scaleType || "linear"]().domain(domain);
+      scaleType = d3.min(domain) <= 0 && d3.max(domain) >= 0 && scaleType === 'log' ?
+        'genericLog' :
+        scaleType === 'nominal' ?
+          'ordinal' :
+          scaleType;
+
+      this.scale = d3.scale[scaleType || 'linear']().domain(domain);
     }
-    
+
     this.scaleType = scaleType;
   },
 
@@ -92,7 +99,7 @@ var AxisModel = Hook.extend({
    * @returns {String} formatted date
    */
   formatDate: function(dateObject) {
-    // improvement would be to check concept type of each space-dimension if it's time. 
+    // improvement would be to check concept type of each space-dimension if it's time.
     // Below code works as long we have one time model: time.
     return this._space.time.format(dateObject);
   }


### PR DESCRIPTION
Fixes `utils.js:907 TypeError: d3.scale[(scaleType || "linear")] is not a function` error on barrank chart's page