### PR TITLE
Add getProp method to utils

### DIFF
--- a/src/base/utils.js
+++ b/src/base/utils.js
@@ -1544,3 +1544,15 @@ export function getValueMD(d, values, keysArray) {
 }
 
 export const isFunction = value => typeof value === "function";
+
+export const getProp = (props, object, defaultValue) => {
+  while (props.length) {
+    const prop = props.shift();
+    if (object.hasOwnProperty(prop)) {
+      object = object[prop];
+    } else {
+      return defaultValue;
+    }
+  }
+  return object;
+};

--- a/src/models/entities.js
+++ b/src/models/entities.js
@@ -118,7 +118,8 @@ const EntitiesModel = DataConnected.extend({
    */
   isShown(d) {
     const dimension = this.getDimension();
-    return this.show[dimension] && this.show[dimension]["$in"] && this.show[dimension]["$in"].indexOf(d[dimension]) !== -1;
+
+    return utils.getProp([dimension, "$in"], this.show, []).includes(d[dimension]);
   },
 
   /**


### PR DESCRIPTION
This is helper for getting some deep props in object. It's added to remove code like
```
this.show[dimension]
&& this.show[dimension]["$in"]
&& this.show[dimension]["$in"].indexOf(d[dimension]) !== -1;
```
when you need to get (+check) nested properties.

Usage:
```
const object = { one: { two: "your value" } };

utils.getProp(["one", "two"], object); // "your value"

// third param is default value that will be returned if there is no such properties in object
utils.getProp(["one", "two", "three"], object, "your default value"); // "your default value"
```