### PR TITLE
Fix selecting color on touch devices

### DIFF
--- a/src/helpers/d3.colorPicker.js
+++ b/src/helpers/d3.colorPicker.js
@@ -311,11 +311,9 @@ export default class ColorPicker {
     this._sampleText.text(value);
 
     const isTouch = isTouchDevice();
-    if (isTouch) {
-      this.show(false);
-    }
 
     this._changeColor(value, isTouch);
+    isTouch && this.show(false);
   }
 
   _changeColor(color, isClick = false) {


### PR DESCRIPTION
#2707

We should change color fist and then hide (because hide method removes callback for color changing)