### PR TITLE
Improve handling of discrete indicators for colors

### DIFF
--- a/src/components/colorlegend/colorlegend.js
+++ b/src/components/colorlegend/colorlegend.js
@@ -184,7 +184,7 @@ const ColorLegend = Component.extend({
 
   ready() {
     this.KEYS = utils.unique(this.model.marker._getAllDimensions({ exceptType: "time" }));
-    this.KEY = this.colorModel.getDataKeys()[0];
+    this.KEY = this.colorModel._getFirstDimension();
     this.markerArray = this.model.marker.getKeys();
     this.which = this.KEY;
     this.canShowMap = false;
@@ -223,12 +223,12 @@ const ColorLegend = Component.extend({
 
     /*POSSIBLE VIEWS:
     Rainbow color legend (for countinuous indicators and properties)
-    Minimap color legend (for discrete properties where shapes are available from CL model)
+    Minimap color legend (for discrete properties where shapes are available via CL marker model)
     List color legend (for other discarete indicators and properties)
-      - constant
-      - individual colors
-      - colors informed by CL model
-      - colors informed by scale
+      - one constant
+      - list of individual colors for every color legend mark (every country is own color)
+      - list of colors informed by CL marker model (world regions)
+      - colors informed by scale (discrete indicators such as one in legal slavery case: legal/illegal switches over time)
     */
 
     //Hide color legend if using a discrete palette that would map to all entities on the chart and therefore will be too long
@@ -510,8 +510,7 @@ const ColorLegend = Component.extend({
                 return result;
               }, {});
 
-            const KEY = _this.colorModel.getDataKeys();
-            _this._highlight(_this.markerArray.filter(d => filterHash[utils.getKey(d, KEY)]));
+            _this._highlight(_this.markerArray.filter(d => filterHash[utils.getKey(d, _this.colorModel.getDataKeys())]));
           });
         } else if (_this.colorModel.use == "property") {
           const filterHash = _this.colorModel.getValidItems()

--- a/src/components/colorlegend/colorlegend.js
+++ b/src/components/colorlegend/colorlegend.js
@@ -86,7 +86,7 @@ const ColorLegend = Component.extend({
     d3.select(this.placeholder.parentNode).classed("vzb-dialog-scrollable", true);
 
     this.colorModel = this.model.color;
-    this.colorlegendMarker = this.colorModel.getColorlegendMarker();
+    this.colorlegendMarker = this.colorModel.getClosestModel("marker_colorlegend");
     if (this.colorlegendMarker) this.colorlegendMarker.on("ready", this.ready.bind(this));
 
 
@@ -195,7 +195,7 @@ const ColorLegend = Component.extend({
     if (this.legendHasOwnModel && this.colorlegendMarker) {
       if (!this.colorlegendMarker._ready) return;
 
-      this.which = this.colorModel.getColorlegendEntities().getDimension();
+      this.which = this.colorlegendMarker.getFirstEntityModel().getDimension();
 
       this.colorlegendMarker.getFrame(this.model.time.value, frame => {
         if (!frame) return utils.warn("colorlegend received empty frame in ready()");
@@ -235,7 +235,7 @@ const ColorLegend = Component.extend({
     //in this case we should show colors in the "find" list instead
     const individualColors = this.colorlegendMarker
       && this.which == this.KEY
-      && utils.comparePlainObjects(this.colorModel.getColorlegendEntities().getFilter(), this.model.entities.getFilter());
+      && utils.comparePlainObjects(this.colorlegendMarker.getFirstEntityModel().getFilter(), this.model.entities.getFilter());
 
     this.subtitleDiv.classed("vzb-hidden", true);
 
@@ -613,7 +613,7 @@ const ColorLegend = Component.extend({
   updateGroupsOpacity(highlight = []) {
     const _this = this;
 
-    const clMarker = this.colorModel.getColorlegendMarker() || {};
+    const clMarker = this.colorlegendMarker || {};
     const OPACITY_REGULAR = clMarker.opacityRegular || 0.8;
     const OPACITY_DIM = clMarker.opacityHighlightDim || 0.5;
     const OPACITY_HIGHLIGHT = 1;

--- a/src/components/indicatorpicker/indicatorpicker.js
+++ b/src/components/indicatorpicker/indicatorpicker.js
@@ -78,7 +78,8 @@ const IndPicker = Component.extend({
               let value = frame[mdl._name][utils.getKey(_highlightedEntity[0], KEYS)];
 
               // resolve strings via the color legend model
-              if (value && mdl._type === "color" && mdl.isDiscrete()) {
+              const conceptType = mdl.getConceptprops().concept_type;
+              if (value && mdl._type === "color" && ["entity_set", "entity_domain"].includes(conceptType)) {
                 const clModel = mdl.getColorlegendMarker();
                 if (clModel.label.getItems()[value]) value = clModel.label.getItems()[value];
               }

--- a/src/models/color.js
+++ b/src/models/color.js
@@ -134,11 +134,12 @@ const ColorModel = Hook.extend({
       const model = _this.getClosestModel(modelName);
       const marker = model.isHook() ? model._parent : model;
       const entities = marker.getClosestModel(marker.space[0]);
+      const conceptType = _this.getConceptprops().concept_type;
 
       //save the references here locally
       _this._syncModelReferences[modelName] = { model, marker, entities };
 
-      if (_this.isDiscrete() && _this.use !== "constant") _this._setSyncModel(model, marker, entities);
+      if (["entity_set", "entity_domain"].includes(conceptType)) _this._setSyncModel(model, marker, entities);
     });
   },
 
@@ -323,8 +324,8 @@ const ColorModel = Hook.extend({
 
         domain = [].concat(this.getUnique(this.which));
         range = domain.map((d, i) => paletteObject[d] || defaultPalette[defaultPaletteKeys[i % defaultPaletteKeys.length]]);
-        domain.push("_default");
-        range.push(paletteObject["_default"]);
+        //domain.push("_default");
+        //range.push(paletteObject["_default"]);
       }
 
       this.scale = d3[`scale${utils.capitalize(scaleType)}`]()

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -45,6 +45,12 @@ const GroupModel = Hook.extend({
       utils.warn("group model: use must be 'property' or 'constant'. Resetting to property...");
       this.use = "property";
     }
+  },
+  
+  // Group model only gets synced with discrete models
+  _receiveSyncModelUpdate(sourceMdl) {
+    if (!sourceMdl.isDiscrete()) return;
+    this._super(sourceMdl);
   }
 
 });

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -46,11 +46,13 @@ const GroupModel = Hook.extend({
       this.use = "property";
     }
   },
-  
+
   // Group model only gets synced with discrete models
   _receiveSyncModelUpdate(sourceMdl) {
-    if (!sourceMdl.isDiscrete()) return;
-    this._super(sourceMdl);
+    const conceptType = sourceMdl.getConceptprops().concept_type;
+    if (["entity_set", "entity_domain"].includes(conceptType) && this.use !== "constant") {
+      this._super(sourceMdl);
+    }
   }
 
 });

--- a/src/models/hook.js
+++ b/src/models/hook.js
@@ -104,6 +104,12 @@ const Hook = DataConnected.extend({
     this._updateSyncModels();
   },
 
+  /**
+  * Tell synced models (list of which defined in confg)
+  * to update depending on the state of this model.
+  * Example: switch colors to a different entity set,
+  * stacking by colors in mountain chart should change accordingly
+  */
   _updateSyncModels() {
     const _this = this;
     this.syncModels.forEach(modelName => {
@@ -112,6 +118,10 @@ const Hook = DataConnected.extend({
     });
   },
 
+  /**
+  * Quietly sets a bunch of properties of this model to be same as
+  * the ones from the model that initiated the sync
+  */
   _receiveSyncModelUpdate(sourceMdl) {
     this.set({ which: sourceMdl.which, data: sourceMdl.data, spaceRef: sourceMdl.spaceRef }, false, false);
   },
@@ -658,7 +668,7 @@ const Hook = DataConnected.extend({
   },
 
   getEntity() {
-    return this._space[this.spaceRef] || this._parent._space[this.spaceRef] || this._parent._space[this._parent.getSpace()[0]];
+    return this._space[this.spaceRef] || this._parent._space[this.spaceRef] || this._parent.getFirstEntityModel();
   },
 
   getDataKeys() {

--- a/src/models/hook.js
+++ b/src/models/hook.js
@@ -17,6 +17,7 @@ const Hook = DataConnected.extend({
 
   getClassDefaults() {
     const defaults = {
+      syncModels: [],
       data: "data",
       which: null
     };
@@ -84,6 +85,8 @@ const Hook = DataConnected.extend({
 
     //support external page indicator frequency tracking
     this._root.trigger("change_hook_which", { "which": obj.which, "hook": this._name });
+
+    this._updateSyncModels();
   },
 
   setScaleType(newValue) {
@@ -98,6 +101,19 @@ const Hook = DataConnected.extend({
   afterPreload() {
     this.autoconfigureModel();
     if (!this.spaceRef) this.spaceRef = this.updateSpaceReference();
+    this._updateSyncModels();
+  },
+
+  _updateSyncModels() {
+    const _this = this;
+    this.syncModels.forEach(modelName => {
+      const model = _this.getClosestModel(modelName);
+      model._receiveSyncModelUpdate(this);
+    });
+  },
+
+  _receiveSyncModelUpdate(sourceMdl) {
+    this.set({ which: sourceMdl.which, data: sourceMdl.data, spaceRef: sourceMdl.spaceRef }, false, false);
   },
 
   autoconfigureModel(autoconfigResult) {

--- a/src/models/marker.js
+++ b/src/models/marker.js
@@ -40,6 +40,25 @@ const Marker = Model.extend({
     this._super();
   },
 
+
+  _receiveSyncModelUpdate(sourceMdl) {
+    const conceptType = sourceMdl.getConceptprops().concept_type;
+    if (["entity_set", "entity_domain"].includes(conceptType)) {
+
+      const newFilter = {
+        dim: sourceMdl.which,
+        show: {}
+      };
+      this.setDataSourceForAllSubhooks(sourceMdl.data);
+      this.getFirstEntityModel().set(newFilter, false, false);
+    }
+  },
+
+  getFirstEntityModel() {
+    return this._space[this.space[0]];
+  },
+
+
   setSpace(newSpace) {
     const subHooks = Object.keys(this.getSubhooks(true));
     const setProps = {};

--- a/src/models/marker.js
+++ b/src/models/marker.js
@@ -40,20 +40,31 @@ const Marker = Model.extend({
     this._super();
   },
 
-
+  /**
+   * Quietly sets this marker's first entity to have a different dimension,
+   * equal to "which" of model that initiated the sync.
+   * Needed for example for color legend, when by changing
+   * color from one entity set to a different entity set,
+   * the legend should request new labels and minimap shapes
+   * for the new entity set. Possibly from a different datasource too.
+   */
   _receiveSyncModelUpdate(sourceMdl) {
     const conceptType = sourceMdl.getConceptprops().concept_type;
     if (["entity_set", "entity_domain"].includes(conceptType)) {
 
       const newFilter = {
         dim: sourceMdl.which,
-        show: {}
+        filter: utils.clone(sourceMdl.getEntity().filter)
       };
       this.setDataSourceForAllSubhooks(sourceMdl.data);
       this.getFirstEntityModel().set(newFilter, false, false);
     }
   },
 
+  /**
+   * A shorthand for one-dimensional situations
+   * allows to get quickly to the entity model of this marker
+   */
   getFirstEntityModel() {
     return this._space[this.space[0]];
   },

--- a/src/models/stack.js
+++ b/src/models/stack.js
@@ -70,8 +70,10 @@ const StackModel = Hook.extend({
 
   // Stack model only gets synced with discrete models
   _receiveSyncModelUpdate(sourceMdl) {
-    if (!sourceMdl.isDiscrete()) return;
-    this._super(sourceMdl);
+    const conceptType = sourceMdl.getConceptprops().concept_type;
+    if (["entity_set", "entity_domain"].includes(conceptType) && this.use !== "constant") {
+      this._super(sourceMdl);
+    }
   },
 
   /**

--- a/src/models/stack.js
+++ b/src/models/stack.js
@@ -68,6 +68,12 @@ const StackModel = Hook.extend({
     return palettes;
   },
 
+  // Stack model only gets synced with discrete models
+  _receiveSyncModelUpdate(sourceMdl) {
+    if (!sourceMdl.isDiscrete()) return;
+    this._super(sourceMdl);
+  },
+
   /**
    * There must be no scale
    */


### PR DESCRIPTION
Vizabi still doesn't do a good job with supporting discrete indicators

Test: 
1. open tools page bubble map and add a new data source:
reader: csv
path: https://raw.githubusercontent.com/vizabi/vizabi-preview/master/src/data/csv/timeright--one-string-indicator--legal-slavery.csv
time in columns: true
name column: false

2. Let page restart, then change color to get data from the added CSV legal slavery

3. Vizabi crashes now. What happened?

Color model sets which to Legal slavery, which is a discrete indicator. Now, because it's discrete, it transfers the update to a connected model color legend in hope that there would be properties like labels or minimap shapes. Color legend tries to request Legal slavery entity properties from WS (its dataset didn't change), WS answers with error, page crashes.

* * *

my change includes replacing the criteria, so color model would only transfer the config to a connected model if a newly selected concept is an entity domain/set

i tested it but please check if i forgot some corner case or if i missed out something